### PR TITLE
Remove leading dash from Plugin Name

### DIFF
--- a/thisismyurl-login-support.php
+++ b/thisismyurl-login-support.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: - Login Support by Christopher Ross
+ * Plugin Name: Login Support by Christopher Ross
  * Plugin URI:  https://thisismyurl.com/
  * Description: Harden login access by allowing a custom login slug and admin security controls.
  * Version:     1.6149.0734


### PR DESCRIPTION
## Summary

WP.org blocks plugin names starting with punctuation; '- Login Support' → 'Login Support'.

## Changes

Plugin Check (PHPCS) fixes — no behaviour changes to production functionality.

## Test plan

- [ ] Install on a WordPress test site and confirm plugin activates without errors
- [ ] Verify Plugin Check passes with no new warnings on the modified files
- [ ] Confirm existing functionality unchanged

_AI-assisted: fixes researched and applied with Claude Sonnet 4.6; reviewed by Christopher Ross._